### PR TITLE
fix matching of old_checksum to checksum in log table

### DIFF
--- a/dbmigrator/src/migrator.rs
+++ b/dbmigrator/src/migrator.rs
@@ -279,7 +279,7 @@ impl Migrator {
             (recipe.old_checksum(), recipe.maximum_version())
         {
             log_version == recipe.version()
-                && log_checksum == old_checksum
+                && log_checksum.starts_with(old_checksum)
                 && matches!(
                     (self.version_comparator)(current_version, maximum_version),
                     std::cmp::Ordering::Less | std::cmp::Ordering::Equal


### PR DESCRIPTION
In `Migrator::match_fix_recipe` the checksum in the log table was compared with a old_checksum of a `RecipeScript` using the `==` operator. The readme states that a partial checksum is allowed so this comparison should use `starts_with`.